### PR TITLE
update commands to avoid conflicts with other twitch commands

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,4 +1,4 @@
-﻿using BaboonAPI.Hooks.Initializer;
+﻿﻿using BaboonAPI.Hooks.Initializer;
 using BaboonAPI.Hooks.Tracks;
 using BepInEx;
 using BepInEx.Configuration;
@@ -75,8 +75,8 @@ namespace TootTallyTwitchIntegration
             ConfigFile config = new ConfigFile(configPath + CONFIG_NAME, true) { SaveOnConfigSet = true };
             ToggleRequestPanel = config.Bind(CONFIG_FIELD, "TogglePanel", KeyCode.F8, "Key to toggle the twitch request panel.");
             EnableRequestsCommand = config.Bind(CONFIG_FIELD, "Enable requests command", true, "Allow people to requests songs using !ttr [songID]");
-            EnableCurrentSongCommand = config.Bind(CONFIG_FIELD, "Enable current song command", true, "!song command that sends a link to the current song into the chat");
-            EnableProfileCommand = config.Bind(CONFIG_FIELD, "Enable profile command", true, "!profile command that links your toottally profile into the chat");
+            EnableCurrentSongCommand = config.Bind(CONFIG_FIELD, "Enable current song command", true, "!ttrsong command that sends a link to the current song into the chat");
+            EnableProfileCommand = config.Bind(CONFIG_FIELD, "Enable profile command", true, "!ttrprofile command that links your toottally profile into the chat");
             SubOnlyMode = config.Bind(CONFIG_FIELD, "Sub-only requests", false, "Only allow subscribers to send requests");
             TwitchUsername = config.Bind(CONFIG_FIELD, "Twitch channel to attach to", "", "Paste your twitch username here");
             TwitchAccessToken = config.Bind(CONFIG_FIELD, "Twitch Access Token", "", "Paste the access token from the website here");

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Press F8 to toggle the request panel in game.
 COMMAND LIST:
 - `!ttr [id]`: Request a song with an id
 - `!ttrhelp`: Display help message on how to request charts
-- `!profile`: Send a your TootTally profile link to the chat (if logged in)
-- `!song`: Sends what song you're currently playing
-- `!queue`: Sends a list of what songs are in your current queue
-- `!last`: Sends what your last played chart is
-- `!history`: Sends what charts you have played recently
+- `!ttrprofile`: Send a your TootTally profile link to the chat (if logged in)
+- `!ttrsong`: Sends what song you're currently playing
+- `!ttrqueue`: Sends a list of what songs are in your current queue
+- `!ttrlast`: Sends what your last played chart is
+- `!ttrhistory`: Sends what charts you have played recently
 
 INSTRUCTIONS:
 1. Instructions for first time usage/setup:

--- a/RequestController.cs
+++ b/RequestController.cs
@@ -53,32 +53,33 @@ namespace TootTallyTwitchIntegration
 
         public void RequestSong(int song_id, string requester, bool isSubscriber = false)
         {
-            
+
             if (!RequesterBlacklist.Contains(requester))
             {
                 if (RequestPanelManager.IsBlocked(song_id))
                 {
-                    Instance.Bot.client.SendMessage(Instance.Bot.CHANNEL, $"!Song #{song_id} is blocked.");
+                    Instance.Bot.client.SendMessage(Instance.Bot.CHANNEL, $"! Song #{song_id} is blocked.");
                     return;
                 }
                 else if (RequestPanelManager.IsDuplicate(song_id) && !RequestQueue.Any(x => x.song_id == song_id))
                 {
-                    Instance.Bot.client.SendMessage(Instance.Bot.CHANNEL, $"!Song #{song_id} already requested.");
+                    Instance.Bot.client.SendMessage(Instance.Bot.CHANNEL, $"! Song #{song_id} already requested.");
                     return;
                 }
                 else if (RequestPanelManager.RequestCount >= Instance.MaxRequestCount.Value)
                 {
-                    Instance.Bot.client.SendMessage(Instance.Bot.CHANNEL, $"!Request cap reached.");
+                    Instance.Bot.client.SendMessage(Instance.Bot.CHANNEL, $"! Request cap reached.");
                     return;
                 }
-                else if (Instance.SubOnlyMode.Value && !isSubscriber) {
+                else if (Instance.SubOnlyMode.Value && !isSubscriber)
+                {
                     return; // Silently ignore non-subscriber requests if in Sub Only mode
                 }
                 UnprocessedRequest request = new UnprocessedRequest();
                 request.song_id = song_id;
                 request.requester = requester;
                 LogInfo($"Accepted request {song_id} by {requester}.");
-                Instance.Bot.client.SendMessage(Instance.Bot.CHANNEL, $"!Song #{song_id} successfully requested.");
+                Instance.Bot.client.SendMessage(Instance.Bot.CHANNEL, $"! Song #{song_id} successfully requested.");
                 RequestQueue.Enqueue(request);
             }
         }

--- a/TwitchBot.cs
+++ b/TwitchBot.cs
@@ -98,40 +98,40 @@ namespace TootTallyTwitchIntegration
                             else
                             {
                                 Plugin.LogInfo("Could not parse request input, ignoring.");
-                                client.SendMessage(CHANNEL, "Invalid song ID. Please try again.");
+                                client.SendMessage(CHANNEL, "! Invalid song ID. Please try again.");
                             }
                         }
                         else
                         {
-                            client.SendMessage(CHANNEL, $"Use !ttr to request a chart use its TootTally Song ID! To get a song ID, search for the song in https://toottally.com/search/ (Example: !ttr 3781)");
+                            client.SendMessage(CHANNEL, $"! Use !ttr to request a chart use its TootTally Song ID! To get a song ID, search for the song in https://toottally.com/search/ (Example: !ttr 3781)");
                         }
                     }
                     break;
                 case "ttrprofile": // Get profile
                     if (Plugin.Instance.EnableProfileCommand.Value && TootTallyUser.userInfo.id > 0)
-                        client.SendMessage(CHANNEL, $"TootTally Profile: https://toottally.com/profile/{TootTallyUser.userInfo.id}");
+                        client.SendMessage(CHANNEL, $"! TootTally Profile: https://toottally.com/profile/{TootTallyUser.userInfo.id}");
                     break;
                 case "ttrsong": // Get current song
                     if (Plugin.Instance.EnableCurrentSongCommand.Value && RequestPanelManager.currentSongID != 0)
                     {
-                        client.SendMessage(CHANNEL, $"Current Song: https://toottally.com/song/{RequestPanelManager.currentSongID}");
+                        client.SendMessage(CHANNEL, $"! Current Song: https://toottally.com/song/{RequestPanelManager.currentSongID}");
                     }
                     break;
                 case "ttrhelp":
                     if (Plugin.Instance.EnableCurrentSongCommand.Value)
-                        client.SendMessage(CHANNEL, $"Use !ttr to request a chart use its TootTally Song ID! To get a song ID, search for the song in https://toottally.com/search/ (Example: !ttr 3781)");
+                        client.SendMessage(CHANNEL, $"! Use !ttr to request a chart use its TootTally Song ID! To get a song ID, search for the song in https://toottally.com/search/ (Example: !ttr 3781)");
                     break;
                 case "ttrqueue":
                     if (Plugin.Instance.EnableCurrentSongCommand.Value)
-                        client.SendMessage(CHANNEL, $"Song Queue: {RequestPanelManager.GetSongQueueIDString()}");
+                        client.SendMessage(CHANNEL, $"! Song Queue: {RequestPanelManager.GetSongQueueIDString()}");
                     break;
                 case "ttrlast":
                     if (Plugin.Instance.EnableCurrentSongCommand.Value)
-                        client.SendMessage(CHANNEL, $"Last song played: {RequestPanelManager.GetLastSongPlayed()}");
+                        client.SendMessage(CHANNEL, $"! Last song played: {RequestPanelManager.GetLastSongPlayed()}");
                     break;
                 case "ttrhistory":
                     if (Plugin.Instance.EnableCurrentSongCommand.Value)
-                        client.SendMessage(CHANNEL, $"Songs played: {RequestPanelManager.GetSongIDHistoryString()}");
+                        client.SendMessage(CHANNEL, $"! Songs played: {RequestPanelManager.GetSongIDHistoryString()}");
                     break;
                 default:
                     break;

--- a/TwitchBot.cs
+++ b/TwitchBot.cs
@@ -98,40 +98,40 @@ namespace TootTallyTwitchIntegration
                             else
                             {
                                 Plugin.LogInfo("Could not parse request input, ignoring.");
-                                client.SendMessage(CHANNEL, "!Invalid song ID. Please try again.");
+                                client.SendMessage(CHANNEL, "Invalid song ID. Please try again.");
                             }
                         }
                         else
                         {
-                            client.SendMessage(CHANNEL, $"!Use !ttr to request a chart use its TootTally Song ID! To get a song ID, search for the song in https://toottally.com/search/ (Example: !ttr 3781)");
+                            client.SendMessage(CHANNEL, $"Use !ttr to request a chart use its TootTally Song ID! To get a song ID, search for the song in https://toottally.com/search/ (Example: !ttr 3781)");
                         }
                     }
                     break;
-                case "profile": // Get profile
+                case "ttrprofile": // Get profile
                     if (Plugin.Instance.EnableProfileCommand.Value && TootTallyUser.userInfo.id > 0)
-                        client.SendMessage(CHANNEL, $"!TootTally Profile: https://toottally.com/profile/{TootTallyUser.userInfo.id}");
+                        client.SendMessage(CHANNEL, $"TootTally Profile: https://toottally.com/profile/{TootTallyUser.userInfo.id}");
                     break;
-                case "song": // Get current song
+                case "ttrsong": // Get current song
                     if (Plugin.Instance.EnableCurrentSongCommand.Value && RequestPanelManager.currentSongID != 0)
                     {
-                        client.SendMessage(CHANNEL, $"!Current Song: https://toottally.com/song/{RequestPanelManager.currentSongID}");
+                        client.SendMessage(CHANNEL, $"Current Song: https://toottally.com/song/{RequestPanelManager.currentSongID}");
                     }
                     break;
                 case "ttrhelp":
                     if (Plugin.Instance.EnableCurrentSongCommand.Value)
-                        client.SendMessage(CHANNEL, $"!Use !ttr to request a chart use its TootTally Song ID! To get a song ID, search for the song in https://toottally.com/search/ (Example: !ttr 3781)");
+                        client.SendMessage(CHANNEL, $"Use !ttr to request a chart use its TootTally Song ID! To get a song ID, search for the song in https://toottally.com/search/ (Example: !ttr 3781)");
                     break;
-                case "queue":
+                case "ttrqueue":
                     if (Plugin.Instance.EnableCurrentSongCommand.Value)
-                        client.SendMessage(CHANNEL, $"!Song Queue: {RequestPanelManager.GetSongQueueIDString()}");
+                        client.SendMessage(CHANNEL, $"Song Queue: {RequestPanelManager.GetSongQueueIDString()}");
                     break;
-                case "last":
+                case "ttrlast":
                     if (Plugin.Instance.EnableCurrentSongCommand.Value)
-                        client.SendMessage(CHANNEL, $"!Last song played: {RequestPanelManager.GetLastSongPlayed()}");
+                        client.SendMessage(CHANNEL, $"Last song played: {RequestPanelManager.GetLastSongPlayed()}");
                     break;
-                case "history":
+                case "ttrhistory":
                     if (Plugin.Instance.EnableCurrentSongCommand.Value)
-                        client.SendMessage(CHANNEL, $"!Songs played: {RequestPanelManager.GetSongIDHistoryString()}");
+                        client.SendMessage(CHANNEL, $"Songs played: {RequestPanelManager.GetSongIDHistoryString()}");
                     break;
                 default:
                     break;


### PR DESCRIPTION
renames all commands to start with `!ttr` instead and removes the leading `!` from the output. should hopefully fix issues with other bots and integrations responding to ttr related messages lol.

technically this is untested but it's also just string changes so surely nothing will go wrong :clueless: